### PR TITLE
[3] Stop mouse button event propagation

### DIFF
--- a/Front End/src/components/LogModal/LogModal.tsx
+++ b/Front End/src/components/LogModal/LogModal.tsx
@@ -56,6 +56,8 @@ export function LogModalBase(props: LogModalProps) {
   return (
     <div>
       <Modal
+        onClick={event => event.stopPropagation()}
+        onMouseDown={event => event.stopPropagation()}
         open={props.open}
         aria-labelledby="modal-modal-title"
         aria-describedby="modal-modal-description"


### PR DESCRIPTION
Solution is explained here better than I ever could:
https://stackoverflow.com/questions/61076053/react-material-ui-open-modal-from-within-autocomplete-lose-focus